### PR TITLE
identify categorical columns/fix pep8

### DIFF
--- a/docs/nominal.md
+++ b/docs/nominal.md
@@ -144,6 +144,23 @@ to replace all missing values with the nan_replace_value. Missing values are Non
 
    The value used to replace missing values with. Only applicable when nan_strategy is set to 'replace'.
 
+#### `identify_nominal_columns(dataset, include=['object', 'category'])`
+Given a dataset, identify categorical columns. This is used internally in `associations` and `numerical_encoding`,
+but can also be used directly.
+
+**Returns:** 
+**`categorical_columns`** : a list of categorical columns
+
+- dataset : a pandas dataframe
+- include : which column types to filter by; default: ['object', 'category'])
+
+**Example:**
+```python
+>> df = pd.DataFrame({'col1': ['a', 'b', 'c', 'a'], 'col2': [3, 4, 2, 1]})
+>> identify_nominal_columns(df)
+['col1']
+```
+
 #### `numerical_encoding(dataset, nominal_columns='auto', drop_single_label=False, drop_fact_dict=True, nan_strategy=REPLACE, nan_replace_value=DEFAULT_REPLACE_VALUE)`
 
 Encoding a data-set with mixed data (numerical and categorical) to a numerical-only data-set,
@@ -221,19 +238,3 @@ to replace all missing values with the nan_replace_value. Missing values are Non
 
    The value used to replace missing values with. Only applicable when nan_strategy is set to 'replace'.
 
-#### `identify_nominal_columns(dataset, include=['object', 'category'])`
-Given a dataset, identify categorical columns. This is used internally in `associations` and `numerical_encoding`,
-but can also be used directly.
-
-**Returns:** 
-**`categorical_columns`** : a list of categorical columns
-
-- dataset : a pandas dataframe
-- include : which column types to filter by; default: ['object', 'category'])
-
-**Example:**
-```python
->> df = pd.DataFrame({'col1': ['a', 'b', 'c', 'a'], 'col2': [3, 4, 2, 1]})
->> identify_nominal_columns(df)
-['col1']
-```

--- a/docs/nominal.md
+++ b/docs/nominal.md
@@ -232,7 +232,8 @@ but can also be used directly.
 - include : which column types to filter by; default: ['object', 'category'])
 
 **Example:**
-    >> df = pd.DataFrame({'col1': ['a', 'b', 'c', 'a'], 'col2': [3, 4, 2, 1]})
-    >> identify_nominal_columns(df)
-    ['col1']
-
+```python
+>> df = pd.DataFrame({'col1': ['a', 'b', 'c', 'a'], 'col2': [3, 4, 2, 1]})
+>> identify_nominal_columns(df)
+['col1']
+```

--- a/docs/nominal.md
+++ b/docs/nominal.md
@@ -5,7 +5,7 @@ type: doc
 
 # nominal
 
-#### `associations(dataset, nominal_columns=None, mark_columns=False, theil_u=False, plot=True, return_results=False, nan_strategy=REPLACE, nan_replace_value=DEFAULT_REPLACE_VALUE, **kwargs)`
+#### `associations(dataset, nominal_columns='auto', mark_columns=False, theil_u=False, plot=True, return_results=False, nan_strategy=REPLACE, nan_replace_value=DEFAULT_REPLACE_VALUE, **kwargs)`
 
 Calculate the correlation/strength-of-association of features in data-set with both categorical (eda_tools) and
 continuous features using:
@@ -23,7 +23,7 @@ continuous features using:
 - **`nominal_columns`** : `string / list / NumPy ndarray`
 
    Names of columns of the data-set which hold categorical values. Can also be the string 'all' to state that all
-columns are categorical, or None (default) to state none are categorical
+columns are categorical, 'auto' (default) to identify nominal columns automatically, or None to state none are categorical
 - **`mark_columns`** : `Boolean` 
 
    _Default: False_
@@ -144,7 +144,7 @@ to replace all missing values with the nan_replace_value. Missing values are Non
 
    The value used to replace missing values with. Only applicable when nan_strategy is set to 'replace'.
 
-#### `numerical_encoding(dataset, nominal_columns='all', drop_single_label=False, drop_fact_dict=True, nan_strategy=REPLACE, nan_replace_value=DEFAULT_REPLACE_VALUE)`
+#### `numerical_encoding(dataset, nominal_columns='auto', drop_single_label=False, drop_fact_dict=True, nan_strategy=REPLACE, nan_replace_value=DEFAULT_REPLACE_VALUE)`
 
 Encoding a data-set with mixed data (numerical and categorical) to a numerical-only data-set,
 using the following logic:
@@ -163,10 +163,11 @@ present in the data-set
    The data-set to encode
 - **`nominal_columns`** : `sequence / string 
 
-   _Default: 'all'_
+   _Default: 'auto'_
 
-   A sequence of the nominal (categorical) columns in the dataset. If string, must be 'all' to state that
-all columns are nominal. If None, nothing happens.
+   Names of columns of the data-set which hold categorical values. Can also be the string 'all' to state that all
+columns are categorical, 'auto' (default) to identify nominal columns automatically, or None to state none are categorical (nothing happens)
+
 - **`drop_single_label`** : `Boolean` 
 
    _Default: False_
@@ -219,3 +220,24 @@ to replace all missing values with the nan_replace_value. Missing values are Non
    _Default: 0.0_
 
    The value used to replace missing values with. Only applicable when nan_strategy is set to 'replace'.
+
+#### `identify_nominal_columns(dataset, include=['object', 'category'])`
+Given a dataset, identify categorical columns. This is used internally in `associations` and `numerical_encoding`,
+but can also be used directly.
+
+**Parameters:**
+-----------
+dataset : a pandas dataframe
+include : which column types to filter by; default: ['object', 'category'])
+
+**Returns:** 
+----------
+categorical_columns : a list of categorical columns
+
+**Example:**
+--------
+>> df = pd.DataFrame({'col1': ['a', 'b', 'c', 'a'], 'col2': [3, 4, 2, 1]})
+>> identify_nominal_columns(df)
+['col1']
+
+

--- a/docs/nominal.md
+++ b/docs/nominal.md
@@ -225,19 +225,14 @@ to replace all missing values with the nan_replace_value. Missing values are Non
 Given a dataset, identify categorical columns. This is used internally in `associations` and `numerical_encoding`,
 but can also be used directly.
 
-**Parameters:**
------------
-dataset : a pandas dataframe
-include : which column types to filter by; default: ['object', 'category'])
-
 **Returns:** 
-----------
-categorical_columns : a list of categorical columns
+**`categorical_columns`** : a list of categorical columns
+
+- dataset : a pandas dataframe
+- include : which column types to filter by; default: ['object', 'category'])
 
 **Example:**
---------
->> df = pd.DataFrame({'col1': ['a', 'b', 'c', 'a'], 'col2': [3, 4, 2, 1]})
->> identify_nominal_columns(df)
-['col1']
-
+    >> df = pd.DataFrame({'col1': ['a', 'b', 'c', 'a'], 'col2': [3, 4, 2, 1]})
+    >> identify_nominal_columns(df)
+    ['col1']
 

--- a/dython/__init__.py
+++ b/dython/__init__.py
@@ -3,15 +3,10 @@ import warnings
 # Version
 __version__ = '0.2.0'
 
-
 # Check for dependencies
 hard_dependencies = [
-    'numpy',
-    'pandas',
-    'seaborn',
-    'scipy',
-    'matplotlib',
-    'sklearn']
+    'numpy', 'pandas', 'seaborn', 'scipy', 'matplotlib', 'sklearn'
+]
 missing_dependencies = []
 
 for dependency in hard_dependencies:
@@ -21,7 +16,8 @@ for dependency in hard_dependencies:
         missing_dependencies.append(dependency)
 
 if missing_dependencies:
-    warnings.warn("Missing required dependencies {0}".format(
-        missing_dependencies), ImportWarning)
+    warnings.warn(
+        "Missing required dependencies {0}".format(missing_dependencies),
+        ImportWarning)
 
 del hard_dependencies, dependency, missing_dependencies

--- a/dython/__init__.py
+++ b/dython/__init__.py
@@ -5,7 +5,13 @@ __version__ = '0.2.0'
 
 
 # Check for dependencies
-hard_dependencies = ['numpy','pandas','seaborn','scipy','matplotlib','sklearn']
+hard_dependencies = [
+    'numpy',
+    'pandas',
+    'seaborn',
+    'scipy',
+    'matplotlib',
+    'sklearn']
 missing_dependencies = []
 
 for dependency in hard_dependencies:
@@ -15,6 +21,7 @@ for dependency in hard_dependencies:
         missing_dependencies.append(dependency)
 
 if missing_dependencies:
-    warnings.warn("Missing required dependencies {0}".format(missing_dependencies), ImportWarning)
+    warnings.warn("Missing required dependencies {0}".format(
+        missing_dependencies), ImportWarning)
 
 del hard_dependencies, dependency, missing_dependencies

--- a/dython/_private.py
+++ b/dython/_private.py
@@ -28,7 +28,9 @@ def convert(data, to):
     else:
         raise ValueError("Unknown data conversion: {}".format(to))
     if converted is None:
-        raise TypeError('cannot handle data conversion of type: {} to {}'.format(type(data),to))
+        raise TypeError(
+            'cannot handle data conversion of type: {} to {}'.format(
+                type(data), to))
     else:
         return converted
 

--- a/dython/examples.py
+++ b/dython/examples.py
@@ -38,7 +38,11 @@ def associations_example():
     Plot an example of an associations heat-map of the Iris dataset features
     """
     iris = datasets.load_iris()
+
+    # Convert int classes to strings to allow associations method auto recognition of categorical columns
+    target = ['C{}'.format(i) for i in iris.target]
+
     X = pd.DataFrame(data=iris.data, columns=iris.feature_names)
-    y = pd.DataFrame(data=iris.target, columns=['target'])
+    y = pd.DataFrame(data=target, columns=['target'])
     df = pd.concat([X, y], axis=1)
-    associations(df, nominal_columns=['target'])
+    associations(df)

--- a/dython/examples.py
+++ b/dython/examples.py
@@ -11,7 +11,8 @@ from dython.nominal import associations
 
 def roc_graph_example():
     """
-    Plot an example ROC graph of an SVM model predictions over the Iris dataset.
+    Plot an example ROC graph of an SVM model predictions over the Iris
+    dataset.
 
     Based on sklearn examples (as was seen on April 2018):
     http://scikit-learn.org/stable/auto_examples/model_selection/plot_roc.html
@@ -22,13 +23,12 @@ def roc_graph_example():
     random_state = np.random.RandomState(0)
     n_samples, n_features = X.shape
     X = np.c_[X, random_state.randn(n_samples, 200 * n_features)]
-    X_train, X_test, y_train, y_test = train_test_split(
-        X, y, test_size=.5, random_state=0)
+    X_train, X_test, y_train, y_test = train_test_split(X,
+                                                        y,
+                                                        test_size=.5,
+                                                        random_state=0)
     classifier = OneVsRestClassifier(
-        svm.SVC(
-            kernel='linear',
-            probability=True,
-            random_state=random_state))
+        svm.SVC(kernel='linear', probability=True, random_state=random_state))
     y_score = classifier.fit(X_train, y_train).decision_function(X_test)
     roc_graph(y_test, y_score)
 

--- a/dython/examples.py
+++ b/dython/examples.py
@@ -22,8 +22,13 @@ def roc_graph_example():
     random_state = np.random.RandomState(0)
     n_samples, n_features = X.shape
     X = np.c_[X, random_state.randn(n_samples, 200 * n_features)]
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=.5, random_state=0)
-    classifier = OneVsRestClassifier(svm.SVC(kernel='linear', probability=True, random_state=random_state))
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=.5, random_state=0)
+    classifier = OneVsRestClassifier(
+        svm.SVC(
+            kernel='linear',
+            probability=True,
+            random_state=random_state))
     y_score = classifier.fit(X_train, y_train).decision_function(X_test)
     roc_graph(y_test, y_score)
 

--- a/dython/model_utils.py
+++ b/dython/model_utils.py
@@ -51,23 +51,24 @@ def binary_roc_graph(y_true, y_pred, **kwargs):
         y_t = [np.argmax(x) for x in y_true]
         y_p = [x[1] for x in y_pred]
     fpr, tpr, _ = roc_curve(y_t, y_p)
-    auc_score = auc(fpr,tpr)
-    color = kwargs.get('color','darkorange')
+    auc_score = auc(fpr, tpr)
+    color = kwargs.get('color', 'darkorange')
     lw = kwargs.get('lw', 2)
-    ls = kwargs.get('ls','-')
+    ls = kwargs.get('ls', '-')
     ms = kwargs.get('ms', 10)
-    fmt = kwargs.get('fmt','.2f')
+    fmt = kwargs.get('fmt', '.2f')
     if 'class_label' in kwargs:
         class_label = ': {}'.format(kwargs['class_label'])
     else:
         class_label = ''
-    if kwargs.get('new_figure',True):
+    if kwargs.get('new_figure', True):
         plt.figure()
-    plt.plot(fpr, tpr, color=color, lw=lw, ls=ls, label='ROC curve{class_label} (AUC = {auc:{fmt}})'
-             .format(class_label=class_label,auc=auc_score,fmt=fmt))
-    if kwargs.get('show_graphs',True):
+    plt.plot(fpr, tpr, color=color, lw=lw, ls=ls,
+             label='ROC curve{class_label} (AUC = {auc:{fmt}})'.format(
+                 class_label=class_label, auc=auc_score, fmt=fmt))
+    if kwargs.get('show_graphs', True):
         _display_plot()
-    if kwargs.get('return_pr',False):
+    if kwargs.get('return_pr', False):
         return {'fpr': fpr, 'tpr': tpr}
 
 
@@ -82,8 +83,15 @@ def _plot_macro_roc(fpr, tpr, n, **kwargs):
     auc_macro = auc(fpr_macro, tpr_macro)
     fmt = kwargs.get('fmt', '.2f')
     lw = kwargs.get('lw', 2)
-    plt.plot(fpr_macro, tpr_macro, label='ROC curve: macro (AUC = {auc:{fmt}})'.format(auc=auc_macro,fmt=fmt),
-             color='navy', ls=':', lw=lw)
+    plt.plot(
+        fpr_macro,
+        tpr_macro,
+        label='ROC curve: macro (AUC = {auc:{fmt}})'.format(
+            auc=auc_macro,
+            fmt=fmt),
+        color='navy',
+        ls=':',
+        lw=lw)
 
 
 def roc_graph(y_true, y_pred, micro=True, macro=True, **kwargs):
@@ -128,16 +136,19 @@ def roc_graph(y_true, y_pred, micro=True, macro=True, **kwargs):
         kwargs['new_figure'] = False
         kwargs['show_graphs'] = False
         kwargs['return_pr'] = True
-        for i in range(0,n):
-            pr = binary_roc_graph(y_true[:,i], y_pred[:,i],
-                                   color=colors[i % len(colors)],class_label=i, **kwargs)
+        for i in range(0, n):
+            pr = binary_roc_graph(
+                y_true[:, i],
+                y_pred[:, i],
+                color=colors[i % len(colors)],
+                class_label=i, **kwargs)
             all_fpr.append(pr['fpr'])
             all_tpr.append(pr['tpr'])
         if micro:
             binary_roc_graph(y_true.ravel(), y_pred.ravel(), ls=':',
-                              color='deeppink', class_label='micro', **kwargs)
+                             color='deeppink', class_label='micro', **kwargs)
         if macro:
-            _plot_macro_roc(all_fpr,all_tpr,n)
+            _plot_macro_roc(all_fpr, all_tpr, n)
         _display_plot()
 
 
@@ -156,6 +167,5 @@ def random_forest_feature_importance(forest, features, **kwargs):
     kwargs : any key-value pairs
         Different options and configurations
     """
-    return sorted(zip(map(lambda x: round(x, kwargs.get('precision',4)), forest.feature_importances_), features),
-                  reverse=True)
-
+    return sorted(zip(map(lambda x: round(x, kwargs.get('precision', 4)),
+                          forest.feature_importances_), features), reverse=True)

--- a/dython/model_utils.py
+++ b/dython/model_utils.py
@@ -1,6 +1,5 @@
 import numpy as np
 import matplotlib.pyplot as plt
-import dython.nominal as nominal
 from scipy import interp
 from sklearn.metrics import roc_curve, auc
 from dython._private import convert
@@ -19,14 +18,18 @@ def _display_plot():
 
 def binary_roc_graph(y_true, y_pred, **kwargs):
     """
-    This function plots a ROC graph of a binary-class predictor. AUC calculation are presented as-well.
-    Data can be either: (1) one dimensional, where the values of y_true represent the true class and y_pred the
-    predicted probability of that class, or (2) two-dimensional, where each line in y_true is a one-hot-encoding
-    of the true class and y_pred holds the predicted probabilities of each class.
-    For example, consider a data-set of two data-points where the true class of the first line is class 0, which
-    was predicted with a probability of 0.6, and the second line's true class is 1, with predicted probability of
-    0.8. In the first configuration, the input will be: y_true = [0,1], y_pred = [0.6,0.8]. In the second
-    configuration, the input will be: y_true = [[1,0],[0,1]], y_pred = [[0.6,0.4],[0.2,0.8]].
+    This function plots a ROC graph of a binary-class predictor. AUC
+    calculation are presented as-well.  Data can be either: (1) one
+    dimensional, where the values of y_true represent the true class and
+    y_pred the predicted probability of that class, or (2) two-dimensional,
+    where each line in y_true is a one-hot-encoding of the true class and
+    y_pred holds the predicted probabilities of each class. For example,
+    consider a data-set of two data-points where the true class of the first
+    line is class 0, which was predicted with a probability of 0.6, and the
+    second line's true class is 1, with predicted probability of 0.8. In the
+    first configuration, the input will be: y_true = [0,1],
+    y_pred = [0.6,0.8]. In the second configuration, the input will be:
+    y_true = [[1,0],[0,1]], y_pred = [[0.6,0.4],[0.2,0.8]].
 
     Based on sklearn examples (as was seen on April 2018):
     http://scikit-learn.org/stable/auto_examples/model_selection/plot_roc.html
@@ -55,7 +58,6 @@ def binary_roc_graph(y_true, y_pred, **kwargs):
     color = kwargs.get('color', 'darkorange')
     lw = kwargs.get('lw', 2)
     ls = kwargs.get('ls', '-')
-    ms = kwargs.get('ms', 10)
     fmt = kwargs.get('fmt', '.2f')
     if 'class_label' in kwargs:
         class_label = ': {}'.format(kwargs['class_label'])
@@ -63,7 +65,11 @@ def binary_roc_graph(y_true, y_pred, **kwargs):
         class_label = ''
     if kwargs.get('new_figure', True):
         plt.figure()
-    plt.plot(fpr, tpr, color=color, lw=lw, ls=ls,
+    plt.plot(fpr,
+             tpr,
+             color=color,
+             lw=lw,
+             ls=ls,
              label='ROC curve{class_label} (AUC = {auc:{fmt}})'.format(
                  class_label=class_label, auc=auc_score, fmt=fmt))
     if kwargs.get('show_graphs', True):
@@ -83,25 +89,25 @@ def _plot_macro_roc(fpr, tpr, n, **kwargs):
     auc_macro = auc(fpr_macro, tpr_macro)
     fmt = kwargs.get('fmt', '.2f')
     lw = kwargs.get('lw', 2)
-    plt.plot(
-        fpr_macro,
-        tpr_macro,
-        label='ROC curve: macro (AUC = {auc:{fmt}})'.format(
-            auc=auc_macro,
-            fmt=fmt),
-        color='navy',
-        ls=':',
-        lw=lw)
+    plt.plot(fpr_macro,
+             tpr_macro,
+             label='ROC curve: macro (AUC = {auc:{fmt}})'.format(auc=auc_macro,
+                                                                 fmt=fmt),
+             color='navy',
+             ls=':',
+             lw=lw)
 
 
 def roc_graph(y_true, y_pred, micro=True, macro=True, **kwargs):
     """
-    Plot a ROC graph of predictor's results (inclusding AUC scores), where each row of y_true and y_pred
-    represent a single example.
-    If there are 1 or two columns only, the data is treated as a binary classification, in which
-    the result is similar to the `binary_roc_graph` method, see its documentation for more information.
-    If there are more then 2 columns, each column is considered a unique class, and a ROC graph and AUC
-    score will be computed for each. A Macro-ROC and Micro-ROC are computed and plotted too by default.
+    Plot a ROC graph of predictor's results (inclusding AUC scores), where each
+    row of y_true and y_pred represent a single example.
+    If there are 1 or two columns only, the data is treated as a binary
+    classification, in which the result is similar to the `binary_roc_graph`
+    method, see its documentation for more information. If there are more then
+    2 columns, each column is considered a unique class, and a ROC graph and
+    AUC score will be computed for each. A Macro-ROC and Micro-ROC are
+    computed and plotted too by default.
 
     Based on sklearn examples (as was seen on April 2018):
     http://scikit-learn.org/stable/auto_examples/model_selection/plot_roc.html
@@ -115,9 +121,11 @@ def roc_graph(y_true, y_pred, micro=True, macro=True, **kwargs):
     y_pred : list / NumPy ndarray
         The predicted classes
     micro : Boolean, default = True
-        Whether to calculate a Micro ROC graph (not applicable for binary cases)
+        Whether to calculate a Micro ROC graph (not applicable for binary
+        cases)
     macro : Boolean, default = True
-        Whether to calculate a Macro ROC graph (not applicable for binary cases)
+        Whether to calculate a Macro ROC graph (not applicable for binary
+        cases)
     kwargs : any key-value pairs
         Different options and configurations
     """
@@ -137,16 +145,20 @@ def roc_graph(y_true, y_pred, micro=True, macro=True, **kwargs):
         kwargs['show_graphs'] = False
         kwargs['return_pr'] = True
         for i in range(0, n):
-            pr = binary_roc_graph(
-                y_true[:, i],
-                y_pred[:, i],
-                color=colors[i % len(colors)],
-                class_label=i, **kwargs)
+            pr = binary_roc_graph(y_true[:, i],
+                                  y_pred[:, i],
+                                  color=colors[i % len(colors)],
+                                  class_label=i,
+                                  **kwargs)
             all_fpr.append(pr['fpr'])
             all_tpr.append(pr['tpr'])
         if micro:
-            binary_roc_graph(y_true.ravel(), y_pred.ravel(), ls=':',
-                             color='deeppink', class_label='micro', **kwargs)
+            binary_roc_graph(y_true.ravel(),
+                             y_pred.ravel(),
+                             ls=':',
+                             color='deeppink',
+                             class_label='micro',
+                             **kwargs)
         if macro:
             _plot_macro_roc(all_fpr, all_tpr, n)
         _display_plot()
@@ -154,18 +166,22 @@ def roc_graph(y_true, y_pred, micro=True, macro=True, **kwargs):
 
 def random_forest_feature_importance(forest, features, **kwargs):
     """
-    Given a trained `sklearn.ensemble.RandomForestClassifier`, plot the different features based on their
-    importance according to the classifier, from the most important to the least.
+    Given a trained `sklearn.ensemble.RandomForestClassifier`, plot the
+    different features based on their importance according to the classifier,
+    from the most important to the least.
 
     Parameters
     ----------
     forest : sklearn.ensemble.RandomForestClassifier
         A trained `RandomForestClassifier`
     features : list
-        A list of the names of the features the classifier was trained on, ordered by the same order the appeared
+        A list of the names of the features the classifier was trained on,
+        ordered by the same order the appeared
         in the training data
     kwargs : any key-value pairs
         Different options and configurations
     """
-    return sorted(zip(map(lambda x: round(x, kwargs.get('precision', 4)),
-                          forest.feature_importances_), features), reverse=True)
+    return sorted(zip(
+        map(lambda x: round(x, kwargs.get('precision', 4)),
+            forest.feature_importances_), features),
+                  reverse=True)

--- a/dython/nominal.py
+++ b/dython/nominal.py
@@ -272,7 +272,8 @@ def associations(
         nominal_columns = columns
     elif nominal_columns == 'auto':
         nominal_columns = identify_nominal_columns(dataset)
-        corr = pd.DataFrame(index=columns, columns=columns)
+
+    corr = pd.DataFrame(index=columns, columns=columns)
     for i in range(0, len(columns)):
         for j in range(i, len(columns)):
             if i == j:

--- a/dython/nominal.py
+++ b/dython/nominal.py
@@ -15,7 +15,11 @@ SKIP = 'skip'
 DEFAULT_REPLACE_VALUE = 0.0
 
 
-def conditional_entropy(x, y, nan_strategy=REPLACE, nan_replace_value=DEFAULT_REPLACE_VALUE):
+def conditional_entropy(
+        x,
+        y,
+        nan_strategy=REPLACE,
+        nan_replace_value=DEFAULT_REPLACE_VALUE):
     """
     Calculates the conditional entropy of x given y: S(x|y)
 
@@ -40,17 +44,21 @@ def conditional_entropy(x, y, nan_strategy=REPLACE, nan_replace_value=DEFAULT_RE
     elif nan_strategy == DROP:
         x, y = remove_incomplete_samples(x, y)
     y_counter = Counter(y)
-    xy_counter = Counter(list(zip(x,y)))
+    xy_counter = Counter(list(zip(x, y)))
     total_occurrences = sum(y_counter.values())
     entropy = 0.0
     for xy in xy_counter.keys():
         p_xy = xy_counter[xy] / total_occurrences
         p_y = y_counter[xy[1]] / total_occurrences
-        entropy += p_xy * math.log(p_y/p_xy)
+        entropy += p_xy * math.log(p_y / p_xy)
     return entropy
 
 
-def cramers_v(x, y, nan_strategy=REPLACE, nan_replace_value=DEFAULT_REPLACE_VALUE):
+def cramers_v(
+        x,
+        y,
+        nan_strategy=REPLACE,
+        nan_replace_value=DEFAULT_REPLACE_VALUE):
     """
     Calculates Cramer's V statistic for categorical-categorical association.
     Uses correction from Bergsma and Wicher, Journal of the Korean Statistical Society 42 (2013): 323-328.
@@ -77,18 +85,22 @@ def cramers_v(x, y, nan_strategy=REPLACE, nan_replace_value=DEFAULT_REPLACE_VALU
         x, y = replace_nan_with_value(x, y, nan_replace_value)
     elif nan_strategy == DROP:
         x, y = remove_incomplete_samples(x, y)
-    confusion_matrix = pd.crosstab(x,y)
+    confusion_matrix = pd.crosstab(x, y)
     chi2 = ss.chi2_contingency(confusion_matrix)[0]
     n = confusion_matrix.sum().sum()
-    phi2 = chi2/n
-    r,k = confusion_matrix.shape
-    phi2corr = max(0, phi2-((k-1)*(r-1))/(n-1))
-    rcorr = r-((r-1)**2)/(n-1)
-    kcorr = k-((k-1)**2)/(n-1)
-    return np.sqrt(phi2corr/min((kcorr-1),(rcorr-1)))
+    phi2 = chi2 / n
+    r, k = confusion_matrix.shape
+    phi2corr = max(0, phi2 - ((k - 1) * (r - 1)) / (n - 1))
+    rcorr = r - ((r - 1)**2) / (n - 1)
+    kcorr = k - ((k - 1)**2) / (n - 1)
+    return np.sqrt(phi2corr / min((kcorr - 1), (rcorr - 1)))
 
 
-def theils_u(x, y, nan_strategy=REPLACE, nan_replace_value=DEFAULT_REPLACE_VALUE):
+def theils_u(
+        x,
+        y,
+        nan_strategy=REPLACE,
+        nan_replace_value=DEFAULT_REPLACE_VALUE):
     """
     Calculates Theil's U statistic (Uncertainty coefficient) for categorical-categorical association.
     This is the uncertainty of x given y: value is on the range of [0,1] - where 0 means y provides no information about
@@ -115,10 +127,10 @@ def theils_u(x, y, nan_strategy=REPLACE, nan_replace_value=DEFAULT_REPLACE_VALUE
         x, y = replace_nan_with_value(x, y, nan_replace_value)
     elif nan_strategy == DROP:
         x, y = remove_incomplete_samples(x, y)
-    s_xy = conditional_entropy(x,y)
+    s_xy = conditional_entropy(x, y)
     x_counter = Counter(x)
     total_occurrences = sum(x_counter.values())
-    p_x = list(map(lambda n: n/total_occurrences, x_counter.values()))
+    p_x = list(map(lambda n: n / total_occurrences, x_counter.values()))
     s_x = ss.entropy(p_x)
     if s_x == 0:
         return 1
@@ -126,7 +138,11 @@ def theils_u(x, y, nan_strategy=REPLACE, nan_replace_value=DEFAULT_REPLACE_VALUE
         return (s_x - s_xy) / s_x
 
 
-def correlation_ratio(categories, measurements, nan_strategy=REPLACE, nan_replace_value=DEFAULT_REPLACE_VALUE):
+def correlation_ratio(
+        categories,
+        measurements,
+        nan_strategy=REPLACE,
+        nan_replace_value=DEFAULT_REPLACE_VALUE):
     """
     Calculates the Correlation Ratio (sometimes marked by the greek letter Eta) for categorical-continuous association.
     Answers the question - given a continuous value of a measurement, is it possible to know which category is it
@@ -151,26 +167,35 @@ def correlation_ratio(categories, measurements, nan_strategy=REPLACE, nan_replac
         The value used to replace missing values with. Only applicable when nan_strategy is set to 'replace'.
     """
     if nan_strategy == REPLACE:
-        categories, measurements = replace_nan_with_value(categories, measurements, nan_replace_value)
+        categories, measurements = replace_nan_with_value(
+            categories, measurements, nan_replace_value)
     elif nan_strategy == DROP:
-        categories, measurements = remove_incomplete_samples(categories, measurements)
+        categories, measurements = remove_incomplete_samples(
+            categories, measurements)
     categories = convert(categories, 'array')
     measurements = convert(measurements, 'array')
     fcat, _ = pd.factorize(categories)
-    cat_num = np.max(fcat)+1
+    cat_num = np.max(fcat) + 1
     y_avg_array = np.zeros(cat_num)
     n_array = np.zeros(cat_num)
-    for i in range(0,cat_num):
+    for i in range(0, cat_num):
         cat_measures = measurements[np.argwhere(fcat == i).flatten()]
         n_array[i] = len(cat_measures)
         y_avg_array[i] = np.average(cat_measures)
-    y_total_avg = np.sum(np.multiply(y_avg_array,n_array))/np.sum(n_array)
-    numerator = np.sum(np.multiply(n_array,np.power(np.subtract(y_avg_array,y_total_avg),2)))
-    denominator = np.sum(np.power(np.subtract(measurements,y_total_avg),2))
+    y_total_avg = np.sum(np.multiply(y_avg_array, n_array)) / np.sum(n_array)
+    numerator = np.sum(
+        np.multiply(
+            n_array,
+            np.power(
+                np.subtract(
+                    y_avg_array,
+                    y_total_avg),
+                2)))
+    denominator = np.sum(np.power(np.subtract(measurements, y_total_avg), 2))
     if numerator == 0:
         eta = 0.0
     else:
-        eta = np.sqrt(numerator/denominator)
+        eta = np.sqrt(numerator / denominator)
     return eta
 
 
@@ -184,8 +209,17 @@ def identify_nominal_columns(dataset):
     return nominal_columns
 
 
-def associations(dataset, nominal_columns='auto', mark_columns=False, theil_u=False, plot=True, return_results=False, nan_strategy=REPLACE,
-                 nan_replace_value=DEFAULT_REPLACE_VALUE, ax=None, **kwargs):
+def associations(
+        dataset,
+        nominal_columns='auto',
+        mark_columns=False,
+        theil_u=False,
+        plot=True,
+        return_results=False,
+        nan_strategy=REPLACE,
+        nan_replace_value=DEFAULT_REPLACE_VALUE,
+        ax=None,
+        **kwargs):
     """
     Calculate the correlation/strength-of-association of features in data-set with both categorical (eda_tools) and
     continuous features using:
@@ -247,41 +281,70 @@ def associations(dataset, nominal_columns='auto', mark_columns=False, theil_u=Fa
                 if columns[i] in nominal_columns:
                     if columns[j] in nominal_columns:
                         if theil_u:
-                            corr[columns[j]][columns[i]] = theils_u(dataset[columns[i]], dataset[columns[j]], nan_strategy=SKIP)
-                            corr[columns[i]][columns[j]] = theils_u(dataset[columns[j]], dataset[columns[i]], nan_strategy=SKIP)
+                            corr[columns[j]][columns[i]] = theils_u(
+                                dataset[columns[i]],
+                                dataset[columns[j]],
+                                nan_strategy=SKIP)
+                            corr[columns[i]][columns[j]] = theils_u(
+                                dataset[columns[j]],
+                                dataset[columns[i]],
+                                nan_strategy=SKIP)
                         else:
-                            cell = cramers_v(dataset[columns[i]], dataset[columns[j]], nan_strategy=SKIP)
+                            cell = cramers_v(
+                                dataset[columns[i]],
+                                dataset[columns[j]],
+                                nan_strategy=SKIP)
                             corr[columns[i]][columns[j]] = cell
                             corr[columns[j]][columns[i]] = cell
                     else:
-                        cell = correlation_ratio(dataset[columns[i]], dataset[columns[j]], nan_strategy=SKIP)
+                        cell = correlation_ratio(
+                            dataset[columns[i]],
+                            dataset[columns[j]],
+                            nan_strategy=SKIP)
                         corr[columns[i]][columns[j]] = cell
                         corr[columns[j]][columns[i]] = cell
                 else:
                     if columns[j] in nominal_columns:
-                        cell = correlation_ratio(dataset[columns[j]], dataset[columns[i]], nan_strategy=SKIP)
+                        cell = correlation_ratio(
+                            dataset[columns[j]],
+                            dataset[columns[i]],
+                            nan_strategy=SKIP)
                         corr[columns[i]][columns[j]] = cell
                         corr[columns[j]][columns[i]] = cell
                     else:
-                        cell, _ = ss.pearsonr(dataset[columns[i]], dataset[columns[j]])
+                        cell, _ = ss.pearsonr(
+                            dataset[columns[i]],
+                            dataset[columns[j]])
                         corr[columns[i]][columns[j]] = cell
                         corr[columns[j]][columns[i]] = cell
     corr.fillna(value=np.nan, inplace=True)
     if mark_columns:
-        marked_columns = ['{} (nom)'.format(col) if col in nominal_columns else '{} (con)'.format(col) for col in columns]
+        marked_columns = [
+            '{} (nom)'.format(col)
+            if col in nominal_columns else '{} (con)'.format(col)
+            for col in columns]
         corr.columns = marked_columns
         corr.index = marked_columns
     if plot:
         if ax is None:
             plt.figure(figsize=kwargs.get('figsize', None))
-        sns.heatmap(corr, annot=kwargs.get('annot', True), fmt=kwargs.get('fmt', '.2f'), ax=ax)
+        sns.heatmap(
+            corr, annot=kwargs.get(
+                'annot', True), fmt=kwargs.get(
+                'fmt', '.2f'), ax=ax)
         if ax is None:
             plt.show()
     if return_results:
         return corr
 
 
-def numerical_encoding(dataset, nominal_columns='auto', drop_single_label=False, drop_fact_dict=True, nan_strategy=REPLACE, nan_replace_value=DEFAULT_REPLACE_VALUE):
+def numerical_encoding(
+        dataset,
+        nominal_columns='auto',
+        drop_single_label=False,
+        drop_fact_dict=True,
+        nan_strategy=REPLACE,
+        nan_replace_value=DEFAULT_REPLACE_VALUE):
     """
     Encoding a data-set with mixed data (numerical and categorical) to a numerical-only data-set,
     using the following logic:
@@ -332,16 +395,18 @@ def numerical_encoding(dataset, nominal_columns='auto', drop_single_label=False,
     binary_columns_dict = dict()
     for col in dataset.columns:
         if col not in nominal_columns:
-            converted_dataset.loc[:,col] = dataset[col]
+            converted_dataset.loc[:, col] = dataset[col]
         else:
             unique_values = pd.unique(dataset[col])
             if len(unique_values) == 1 and not drop_single_label:
-                converted_dataset.loc[:,col] = 0
+                converted_dataset.loc[:, col] = 0
             elif len(unique_values) == 2:
-                converted_dataset.loc[:,col], binary_columns_dict[col] = pd.factorize(dataset[col])
+                converted_dataset.loc[:, col], binary_columns_dict[col] = pd.factorize(
+                    dataset[col])
             else:
-                dummies = pd.get_dummies(dataset[col],prefix=col)
-                converted_dataset = pd.concat([converted_dataset,dummies],axis=1)
+                dummies = pd.get_dummies(dataset[col], prefix=col)
+                converted_dataset = pd.concat(
+                    [converted_dataset, dummies], axis=1)
     if drop_fact_dict:
         return converted_dataset
     else:

--- a/dython/nominal.py
+++ b/dython/nominal.py
@@ -1,11 +1,13 @@
 import math
+from collections import Counter
 import numpy as np
 import pandas as pd
 import seaborn as sns
 import scipy.stats as ss
 import matplotlib.pyplot as plt
-from collections import Counter
-from dython._private import convert, remove_incomplete_samples, replace_nan_with_value
+from dython._private import (
+    convert, remove_incomplete_samples, replace_nan_with_value
+)
 
 REPLACE = 'replace'
 DROP = 'drop'
@@ -15,11 +17,10 @@ SKIP = 'skip'
 DEFAULT_REPLACE_VALUE = 0.0
 
 
-def conditional_entropy(
-        x,
-        y,
-        nan_strategy=REPLACE,
-        nan_replace_value=DEFAULT_REPLACE_VALUE):
+def conditional_entropy(x,
+                        y,
+                        nan_strategy=REPLACE,
+                        nan_replace_value=DEFAULT_REPLACE_VALUE):
     """
     Calculates the conditional entropy of x given y: S(x|y)
 
@@ -34,10 +35,12 @@ def conditional_entropy(
     y : list / NumPy ndarray / Pandas Series
         A sequence of measurements
     nan_strategy : string, default = 'replace'
-        How to handle missing values: can be either 'drop' to remove samples with missing values, or 'replace'
-        to replace all missing values with the nan_replace_value. Missing values are None and np.nan.
+        How to handle missing values: can be either 'drop' to remove samples
+        with missing values, or 'replace' to replace all missing values with
+        the nan_replace_value. Missing values are None and np.nan.
     nan_replace_value : any, default = 0.0
-        The value used to replace missing values with. Only applicable when nan_strategy is set to 'replace'.
+        The value used to replace missing values with. Only applicable when
+        nan_strategy is set to 'replace'.
     """
     if nan_strategy == REPLACE:
         x, y = replace_nan_with_value(x, y, nan_replace_value)
@@ -54,14 +57,14 @@ def conditional_entropy(
     return entropy
 
 
-def cramers_v(
-        x,
-        y,
-        nan_strategy=REPLACE,
-        nan_replace_value=DEFAULT_REPLACE_VALUE):
+def cramers_v(x,
+              y,
+              nan_strategy=REPLACE,
+              nan_replace_value=DEFAULT_REPLACE_VALUE):
     """
     Calculates Cramer's V statistic for categorical-categorical association.
-    Uses correction from Bergsma and Wicher, Journal of the Korean Statistical Society 42 (2013): 323-328.
+    Uses correction from Bergsma and Wicher, Journal of the Korean Statistical
+    Society 42 (2013): 323-328.
     This is a symmetric coefficient: V(x,y) = V(y,x)
 
     Original function taken from: https://stackoverflow.com/a/46498792/5863503
@@ -76,10 +79,12 @@ def cramers_v(
     y : list / NumPy ndarray / Pandas Series
         A sequence of categorical measurements
     nan_strategy : string, default = 'replace'
-        How to handle missing values: can be either 'drop' to remove samples with missing values, or 'replace'
-        to replace all missing values with the nan_replace_value. Missing values are None and np.nan.
+        How to handle missing values: can be either 'drop' to remove samples
+        with missing values, or 'replace' to replace all missing values with
+        the nan_replace_value. Missing values are None and np.nan.
     nan_replace_value : any, default = 0.0
-        The value used to replace missing values with. Only applicable when nan_strategy is set to 'replace'.
+        The value used to replace missing values with. Only applicable when
+        nan_strategy is set to 'replace'.
     """
     if nan_strategy == REPLACE:
         x, y = replace_nan_with_value(x, y, nan_replace_value)
@@ -96,15 +101,16 @@ def cramers_v(
     return np.sqrt(phi2corr / min((kcorr - 1), (rcorr - 1)))
 
 
-def theils_u(
-        x,
-        y,
-        nan_strategy=REPLACE,
-        nan_replace_value=DEFAULT_REPLACE_VALUE):
+def theils_u(x,
+             y,
+             nan_strategy=REPLACE,
+             nan_replace_value=DEFAULT_REPLACE_VALUE):
     """
-    Calculates Theil's U statistic (Uncertainty coefficient) for categorical-categorical association.
-    This is the uncertainty of x given y: value is on the range of [0,1] - where 0 means y provides no information about
+    Calculates Theil's U statistic (Uncertainty coefficient) for categorical-
+    categorical association. This is the uncertainty of x given y: value is
+    on the range of [0,1] - where 0 means y provides no information about
     x, and 1 means y provides full information about x.
+
     This is an asymmetric coefficient: U(x,y) != U(y,x)
 
     Wikipedia: https://en.wikipedia.org/wiki/Uncertainty_coefficient
@@ -118,10 +124,12 @@ def theils_u(
     y : list / NumPy ndarray / Pandas Series
         A sequence of categorical measurements
     nan_strategy : string, default = 'replace'
-        How to handle missing values: can be either 'drop' to remove samples with missing values, or 'replace'
-        to replace all missing values with the nan_replace_value. Missing values are None and np.nan.
+        How to handle missing values: can be either 'drop' to remove samples
+        with missing values, or 'replace' to replace all missing values with
+        the nan_replace_value. Missing values are None and np.nan.
     nan_replace_value : any, default = 0.0
-        The value used to replace missing values with. Only applicable when nan_strategy is set to 'replace'.
+        The value used to replace missing values with. Only applicable when
+        nan_strategy is set to 'replace'.
     """
     if nan_strategy == REPLACE:
         x, y = replace_nan_with_value(x, y, nan_replace_value)
@@ -138,17 +146,20 @@ def theils_u(
         return (s_x - s_xy) / s_x
 
 
-def correlation_ratio(
-        categories,
-        measurements,
-        nan_strategy=REPLACE,
-        nan_replace_value=DEFAULT_REPLACE_VALUE):
+def correlation_ratio(categories,
+                      measurements,
+                      nan_strategy=REPLACE,
+                      nan_replace_value=DEFAULT_REPLACE_VALUE):
     """
-    Calculates the Correlation Ratio (sometimes marked by the greek letter Eta) for categorical-continuous association.
-    Answers the question - given a continuous value of a measurement, is it possible to know which category is it
-    associated with?
-    Value is in the range [0,1], where 0 means a category cannot be determined by a continuous measurement, and 1 means
-    a category can be determined with absolute certainty.
+    Calculates the Correlation Ratio (sometimes marked by the greek letter Eta)
+    for categorical-continuous association.
+
+    Answers the question - given a continuous value of a measurement, is it
+    possible to know which category is it associated with?
+
+    Value is in the range [0,1], where 0 means a category cannot be determined
+    by a continuous measurement, and 1 means a category can be determined with
+    absolute certainty.
 
     Wikipedia: https://en.wikipedia.org/wiki/Correlation_ratio
 
@@ -161,10 +172,12 @@ def correlation_ratio(
     measurements : list / NumPy ndarray / Pandas Series
         A sequence of continuous measurements
     nan_strategy : string, default = 'replace'
-        How to handle missing values: can be either 'drop' to remove samples with missing values, or 'replace'
-        to replace all missing values with the nan_replace_value. Missing values are None and np.nan.
+        How to handle missing values: can be either 'drop' to remove samples
+        with missing values, or 'replace' to replace all missing values with
+        the nan_replace_value. Missing values are None and np.nan.
     nan_replace_value : any, default = 0.0
-        The value used to replace missing values with. Only applicable when nan_strategy is set to 'replace'.
+        The value used to replace missing values with. Only applicable when
+        nan_strategy is set to 'replace'.
     """
     if nan_strategy == REPLACE:
         categories, measurements = replace_nan_with_value(
@@ -184,13 +197,8 @@ def correlation_ratio(
         y_avg_array[i] = np.average(cat_measures)
     y_total_avg = np.sum(np.multiply(y_avg_array, n_array)) / np.sum(n_array)
     numerator = np.sum(
-        np.multiply(
-            n_array,
-            np.power(
-                np.subtract(
-                    y_avg_array,
-                    y_total_avg),
-                2)))
+        np.multiply(n_array, np.power(np.subtract(y_avg_array, y_total_avg),
+                                      2)))
     denominator = np.sum(np.power(np.subtract(measurements, y_total_avg), 2))
     if numerator == 0:
         eta = 0.0
@@ -219,31 +227,29 @@ def identify_nominal_columns(dataset, include=['object', 'category']):
 
     """
     dataset = convert(dataset, 'dataframe')
-    nominal_columns = list(
-        dataset.select_dtypes(include=include).columns
-    )
+    nominal_columns = list(dataset.select_dtypes(include=include).columns)
     return nominal_columns
 
 
-def associations(
-        dataset,
-        nominal_columns='auto',
-        mark_columns=False,
-        theil_u=False,
-        plot=True,
-        return_results=False,
-        nan_strategy=REPLACE,
-        nan_replace_value=DEFAULT_REPLACE_VALUE,
-        ax=None,
-        **kwargs):
+def associations(dataset,
+                 nominal_columns='auto',
+                 mark_columns=False,
+                 theil_u=False,
+                 plot=True,
+                 return_results=False,
+                 nan_strategy=REPLACE,
+                 nan_replace_value=DEFAULT_REPLACE_VALUE,
+                 ax=None,
+                 **kwargs):
     """
-    Calculate the correlation/strength-of-association of features in data-set with both categorical (eda_tools) and
-    continuous features using:
+    Calculate the correlation/strength-of-association of features in data-set
+    with both categorical (eda_tools) and continuous features using:
      * Pearson's R for continuous-continuous cases
      * Correlation Ratio for categorical-continuous cases
      * Cramer's V or Theil's U for categorical-categorical cases
 
-    **Returns:** a DataFrame of the correlation/strength-of-association between all features
+    **Returns:** a DataFrame of the correlation/strength-of-association between
+    all features
 
     **Example:** see `associations_example` under `dython.examples`
 
@@ -252,23 +258,30 @@ def associations(
     dataset : NumPy ndarray / Pandas DataFrame
         The data-set for which the features' correlation is computed
     nominal_columns : string / list / NumPy ndarray
-        Names of columns of the data-set which hold categorical values. Can also be the string 'all' to state that all
-        columns are categorical, 'auto' (default) to try to identify nominal columns, or None to state none are categorical
+        Names of columns of the data-set which hold categorical values. Can
+        also be the string 'all' to state that all columns are categorical,
+        'auto' (default) to try to identify nominal columns, or None to state
+        none are categorical
     mark_columns : Boolean, default = False
-        if True, output's columns' names will have a suffix of '(nom)' or '(con)' based on there type (eda_tools or
-        continuous), as provided by nominal_columns
+        if True, output's columns' names will have a suffix of '(nom)' or
+        '(con)' based on there type (eda_tools or continuous), as provided
+        by nominal_columns
     theil_u : Boolean, default = False
-        In the case of categorical-categorical feaures, use Theil's U instead of Cramer's V
+        In the case of categorical-categorical feaures, use Theil's U instead
+        of Cramer's V
     plot : Boolean, default = True
         If True, plot a heat-map of the correlation matrix
     return_results : Boolean, default = False
-        If True, the function will return a Pandas DataFrame of the computed associations
+        If True, the function will return a Pandas DataFrame of the computed
+        associations
     nan_strategy : string, default = 'replace'
-        How to handle missing values: can be either 'drop_samples' to remove samples with missing values,
-        'drop_features' to remove features (columns) with missing values, or 'replace' to replace all missing
+        How to handle missing values: can be either 'drop_samples' to remove
+        samples with missing values, 'drop_features' to remove features
+        (columns) with missing values, or 'replace' to replace all missing
         values with the nan_replace_value. Missing values are None and np.nan.
     nan_replace_value : any, default = 0.0
-        The value used to replace missing values with. Only applicable when nan_strategy is set to 'replace'
+        The value used to replace missing values with. Only applicable when
+        nan_strategy is set to 'replace'
     ax : matplotlib ax, default = None
       Matplotlib Axis on which the heat-map will be plotted
     kwargs : any key-value pairs
@@ -307,31 +320,27 @@ def associations(
                                 dataset[columns[i]],
                                 nan_strategy=SKIP)
                         else:
-                            cell = cramers_v(
-                                dataset[columns[i]],
-                                dataset[columns[j]],
-                                nan_strategy=SKIP)
+                            cell = cramers_v(dataset[columns[i]],
+                                             dataset[columns[j]],
+                                             nan_strategy=SKIP)
                             corr[columns[i]][columns[j]] = cell
                             corr[columns[j]][columns[i]] = cell
                     else:
-                        cell = correlation_ratio(
-                            dataset[columns[i]],
-                            dataset[columns[j]],
-                            nan_strategy=SKIP)
+                        cell = correlation_ratio(dataset[columns[i]],
+                                                 dataset[columns[j]],
+                                                 nan_strategy=SKIP)
                         corr[columns[i]][columns[j]] = cell
                         corr[columns[j]][columns[i]] = cell
                 else:
                     if columns[j] in nominal_columns:
-                        cell = correlation_ratio(
-                            dataset[columns[j]],
-                            dataset[columns[i]],
-                            nan_strategy=SKIP)
+                        cell = correlation_ratio(dataset[columns[j]],
+                                                 dataset[columns[i]],
+                                                 nan_strategy=SKIP)
                         corr[columns[i]][columns[j]] = cell
                         corr[columns[j]][columns[i]] = cell
                     else:
-                        cell, _ = ss.pearsonr(
-                            dataset[columns[i]],
-                            dataset[columns[j]])
+                        cell, _ = ss.pearsonr(dataset[columns[i]],
+                                              dataset[columns[j]])
                         corr[columns[i]][columns[j]] = cell
                         corr[columns[j]][columns[i]] = cell
     corr.fillna(value=np.nan, inplace=True)
@@ -339,40 +348,45 @@ def associations(
         marked_columns = [
             '{} (nom)'.format(col)
             if col in nominal_columns else '{} (con)'.format(col)
-            for col in columns]
+            for col in columns
+        ]
         corr.columns = marked_columns
         corr.index = marked_columns
     if plot:
         if ax is None:
             plt.figure(figsize=kwargs.get('figsize', None))
-        sns.heatmap(
-            corr, annot=kwargs.get(
-                'annot', True), fmt=kwargs.get(
-                'fmt', '.2f'), ax=ax)
+        sns.heatmap(corr,
+                    annot=kwargs.get('annot', True),
+                    fmt=kwargs.get('fmt', '.2f'),
+                    ax=ax)
         if ax is None:
             plt.show()
     if return_results:
         return corr
 
 
-def numerical_encoding(
-        dataset,
-        nominal_columns='auto',
-        drop_single_label=False,
-        drop_fact_dict=True,
-        nan_strategy=REPLACE,
-        nan_replace_value=DEFAULT_REPLACE_VALUE):
+def numerical_encoding(dataset,
+                       nominal_columns='auto',
+                       drop_single_label=False,
+                       drop_fact_dict=True,
+                       nan_strategy=REPLACE,
+                       nan_replace_value=DEFAULT_REPLACE_VALUE):
     """
-    Encoding a data-set with mixed data (numerical and categorical) to a numerical-only data-set,
-    using the following logic:
-    * categorical with only a single value will be marked as zero (or dropped, if requested)
-    * categorical with two values will be replaced with the result of Pandas `factorize`
-    * categorical with more than two values will be replaced with the result of Pandas `get_dummies`
+    Encoding a data-set with mixed data (numerical and categorical) to a
+    numerical-only data-set using the following logic:
+    * categorical with only a single value will be marked as zero (or dropped,
+        if requested)
+    * categorical with two values will be replaced with the result of Pandas
+        `factorize`
+    * categorical with more than two values will be replaced with the result
+        of Pandas `get_dummies`
     * numerical columns will not be modified
 
-    **Returns:** DataFrame or (DataFrame, dict). If `drop_fact_dict` is True, returns the encoded DataFrame.
-    else, returns a tuple of the encoded DataFrame and dictionary, where each key is a two-value column, and the
-    value is the original labels, as supplied by Pandas `factorize`. Will be empty if no two-value columns are
+    **Returns:** DataFrame or (DataFrame, dict). If `drop_fact_dict` is True,
+    returns the encoded DataFrame.
+    else, returns a tuple of the encoded DataFrame and dictionary, where each
+    key is a two-value column, and the value is the original labels, as
+    supplied by Pandas `factorize`. Will be empty if no two-value columns are
     present in the data-set
 
     Parameters
@@ -380,20 +394,24 @@ def numerical_encoding(
     dataset : NumPy ndarray / Pandas DataFrame
         The data-set to encode
     nominal_columns : sequence / string. default = 'all'
-        A sequence of the nominal (categorical) columns in the dataset. If string, must be 'all' to state that
-        all columns are nominal. If None, nothing happens. If 'auto', categorical columns will be identified based
-        on dtype.
+        A sequence of the nominal (categorical) columns in the dataset. If
+        string, must be 'all' to state that all columns are nominal. If None,
+        nothing happens. If 'auto', categorical columns will be identified
+        based on dtype.
     drop_single_label : Boolean, default = False
         If True, nominal columns with a only a single value will be dropped.
     drop_fact_dict : Boolean, default = True
-        If True, the return value will be the encoded DataFrame alone. If False, it will be a tuple of
-        the DataFrame and the dictionary of the binary factorization (originating from pd.factorize)
+        If True, the return value will be the encoded DataFrame alone. If
+        False, it will be a tuple of the DataFrame and the dictionary of the
+        binary factorization (originating from pd.factorize)
     nan_strategy : string, default = 'replace'
-        How to handle missing values: can be either 'drop_samples' to remove samples with missing values,
-        'drop_features' to remove features (columns) with missing values, or 'replace' to replace all missing
+        How to handle missing values: can be either 'drop_samples' to remove
+        samples with missing values, 'drop_features' to remove features
+        (columns) with missing values, or 'replace' to replace all missing
         values with the nan_replace_value. Missing values are None and np.nan.
     nan_replace_value : any, default = 0.0
-        The value used to replace missing values with. Only applicable when nan_strategy is set to 'replace'
+        The value used to replace missing values with. Only applicable when nan
+        _strategy is set to 'replace'
     """
     dataset = convert(dataset, 'dataframe')
     if nan_strategy == REPLACE:
@@ -418,12 +436,12 @@ def numerical_encoding(
             if len(unique_values) == 1 and not drop_single_label:
                 converted_dataset.loc[:, col] = 0
             elif len(unique_values) == 2:
-                converted_dataset.loc[:, col], binary_columns_dict[col] = pd.factorize(
-                    dataset[col])
+                converted_dataset.loc[:, col], binary_columns_dict[
+                    col] = pd.factorize(dataset[col])
             else:
                 dummies = pd.get_dummies(dataset[col], prefix=col)
-                converted_dataset = pd.concat(
-                    [converted_dataset, dummies], axis=1)
+                converted_dataset = pd.concat([converted_dataset, dummies],
+                                              axis=1)
     if drop_fact_dict:
         return converted_dataset
     else:

--- a/dython/nominal.py
+++ b/dython/nominal.py
@@ -199,12 +199,28 @@ def correlation_ratio(
     return eta
 
 
-def identify_nominal_columns(dataset):
+def identify_nominal_columns(dataset, include=['object', 'category']):
+    """Given a dataset, identify categorical columns.
+
+    Parameters:
+    -----------
+    dataset : a pandas dataframe
+    include : which column types to filter by; default: ['object', 'category'])
+
+    Returns:
+    --------
+    categorical_columns : a list of categorical columns
+
+    Example:
+    --------
+    >> df = pd.DataFrame({'col1': ['a', 'b', 'c', 'a'], 'col2': [3, 4, 2, 1]})
+    >> identify_nominal_columns(df)
+    ['col1']
+
+    """
     dataset = convert(dataset, 'dataframe')
     nominal_columns = list(
-        dataset.select_dtypes(include=[
-            'category', 'object'
-        ]).columns
+        dataset.select_dtypes(include=include).columns
     )
     return nominal_columns
 

--- a/dython/sampling.py
+++ b/dython/sampling.py
@@ -12,13 +12,14 @@ def weighted_sampling(numbers, k=1, with_replacement=False, **kwargs):
     numbers : List or np.ndarray
         numbers to sample
     k : int, default = 1
-        How many numbers to sample. Choosing `k=None` will yield a single number
+        How many numbers to sample. Choosing `k=None` will yield a single
+        number
     with_replacement : Boolean, default = False
         Allow replacement or not
     """
     sampled = np.random.choice(numbers, size=k, replace=with_replacement)
-    if (isinstance(numbers, list) or kwargs.get(
-            'to_list', False)) and k is not None:
+    if (isinstance(numbers, list)
+            or kwargs.get('to_list', False)) and k is not None:
         sampled = sampled.tolist()
     return sampled
 
@@ -34,7 +35,8 @@ def boltzmann_sampling(numbers, k=1, with_replacement=False):
     numbers : List or np.ndarray
         numbers to sample
     k : int, default = 1
-        How many numbers to sample. Choosing `k=None` will yield a single number
+        How many numbers to sample. Choosing `k=None` will yield a single
+        number
     with_replacement : Boolean, default = False
         Allow replacement or not
     """
@@ -43,10 +45,7 @@ def boltzmann_sampling(numbers, k=1, with_replacement=False):
     exp_sum = exp_numbers.sum()
     scaling_func = np.vectorize(lambda x: x / exp_sum)
     b_numbers = scaling_func(exp_numbers)
-    return weighted_sampling(
-        b_numbers,
-        k=k,
-        with_replacement=with_replacement,
-        to_list=isinstance(
-            numbers,
-            list))
+    return weighted_sampling(b_numbers,
+                             k=k,
+                             with_replacement=with_replacement,
+                             to_list=isinstance(numbers, list))

--- a/dython/sampling.py
+++ b/dython/sampling.py
@@ -17,7 +17,8 @@ def weighted_sampling(numbers, k=1, with_replacement=False, **kwargs):
         Allow replacement or not
     """
     sampled = np.random.choice(numbers, size=k, replace=with_replacement)
-    if (isinstance(numbers, list) or kwargs.get('to_list', False)) and k is not None:
+    if (isinstance(numbers, list) or kwargs.get(
+            'to_list', False)) and k is not None:
         sampled = sampled.tolist()
     return sampled
 
@@ -40,6 +41,12 @@ def boltzmann_sampling(numbers, k=1, with_replacement=False):
     exp_func = np.vectorize(lambda x: np.exp(x))
     exp_numbers = exp_func(numbers)
     exp_sum = exp_numbers.sum()
-    scaling_func = np.vectorize(lambda x: x/exp_sum)
+    scaling_func = np.vectorize(lambda x: x / exp_sum)
     b_numbers = scaling_func(exp_numbers)
-    return weighted_sampling(b_numbers, k=k, with_replacement=with_replacement, to_list=isinstance(numbers, list))
+    return weighted_sampling(
+        b_numbers,
+        k=k,
+        with_replacement=with_replacement,
+        to_list=isinstance(
+            numbers,
+            list))

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import pathlib
 from setuptools import setup, find_packages
 
-VERSION = '0.3.1'
+VERSION = '0.4.0'
 HERE = pathlib.Path(__file__).parent
 README = (HERE / "README.md").read_text()
 


### PR DESCRIPTION
Hi
I really like the correlation functionality. However, I thought it could be easier if there was a functionality to consider categorical, the ones that are either marked categorical (pd.Categorical) or strings. So I've created a flag option, nominal_columns='auto'.

The example can now run like this:
```
import pandas as pd
from sklearn import datasets
from dython.nominal import associations
iris = datasets.load_iris()
X = pd.DataFrame(data=iris.data, columns=iris.feature_names)
y = pd.DataFrame(data=iris.target, columns=['target'])
df = pd.concat([X, y], axis=1)
associations(df, nominal_columns='auto')
```

While looking at the code, I've also fixed some pep8. If you don't like this, ignore the second commit.

Cheers.