### PR TITLE
Can choose to only show half of correlation matrix

### DIFF
--- a/dython/nominal.py
+++ b/dython/nominal.py
@@ -613,7 +613,7 @@ def associations(dataset,
         Plotted graph title
     filename : string or None, default = None
         If not None, plot will be saved to the given file name
-    upper_half : bool or none, default = None
+    upper_half : bool or None, default = None
         If False, lower half will be displayed, if True, upper half
         will be displayed, if None, both halves are rendered
 

--- a/dython/nominal.py
+++ b/dython/nominal.py
@@ -534,7 +534,8 @@ def associations(dataset,
                  plot=True,
                  clustering=False,
                  title=None,
-                 filename=None
+                 filename=None,
+                 upper_half=None
                  ):
     """
     Calculate the correlation/strength-of-association of features in data-set
@@ -612,6 +613,9 @@ def associations(dataset,
         Plotted graph title
     filename : string or None, default = None
         If not None, plot will be saved to the given file name
+    upper_half : bool or none, default = None
+        If False, lower half will be displayed, if True, upper half
+        will be displayed, if None, both halves are rendered
 
     Returns:
     --------
@@ -665,6 +669,11 @@ def associations(dataset,
     else:
         sv_mask = np.ones_like(corr)
     mask = np.vectorize(lambda x: not bool(x))(inf_nan_mask) + np.vectorize(lambda x: not bool(x))(sv_mask)
+    if upper_half is not None:
+        if upper_half:
+            mask = np.tril(np.ones_like(corr, dtype=bool))
+        if not upper_half:
+            mask = np.triu(np.ones_like(corr, dtype=bool))
     vmin = vmin or (-1.0 if len(columns) - len(nominal_columns) >= 2 else 0.0)
     ax = sns.heatmap(corr,
                      cmap=cmap,


### PR DESCRIPTION
Adds the optional parameter of `upper_half` to `associations()`.  If not explicitly set by the user the entire matrix is plotted. If set to `True`, only the upper half is shown and if set to `False` then only the lower half is shown. It might be easier to just allow a custom mask, and accept more kwargs from the seaborn heatmap call itself (a more well-rounded solution to this as well as #92 ), so happy to discuss possible solutions to allow the tool to more seamlessly fit into a variety of workflows.