### PR TITLE
Change drop_samples strategy by removing nan values in a pair of columns instead of full table when calculating score. Add checker for zero-size array error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,38 @@
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/dython)](https://pypistats.org/packages/dython)
 [![License](https://img.shields.io/pypi/l/dython)](https://github.com/shakedzy/dython/blob/master/LICENSE)
 
+[![Coffee](https://img.shields.io/badge/-buy_me_a%C2%A0coffee-gray?logo=buy-me-a-coffee&color=ff69b4)](https://ko-fi.com/shakedzy)
+
 A set of **D**ata analysis tools in p**YTHON** 3.x.
 
-Dython was implemented by shakedyzy. The official github is [here](https://github.com/shakedzy/dython). I modified this following my usage: only remove nan value in a pair of features when calculating association score.
+Dython was designed with analysis usage in mind - meaning ease-of-use, functionality and readability are the core 
+values of this library. Production-grade performance, on the other hand, were not considered.
+
+## Documentation:
+Modules documentation can be found on [shakedzy.xyz/dython](http://shakedzy.xyz/dython)
 
 ## Installation:
-If you wish to install my repo:
+Dython can be installed directly using `pip`:
 ```
-pip install git+https://github.com/mainguyenanhvu/dython.git
+pip install dython
+```
+Or, via the `conda` package manager:
+```
+conda install -c conda-forge dython
+```
+If you wish to install from source:
+```
+pip install git+https://github.com/shakedzy/dython.git
 ```
 
 **Dependencies:** `numpy`, `pandas`, `seaborn`, `scipy`, `matplotlib`, `sklearn`, `scikit-plot`
 
+## Contributing:
+Contributions are always welcomed - if you found something you can fix, or have an idea for a new feature, feel free to write it and open a pull request. Please make sure to go over the [contributions guidelines](https://github.com/shakedzy/dython/blob/master/CONTRIBUTING.md).
+
+## Change log:
+Change log is available, see [CHANGELOG.md](https://github.com/shakedzy/dython/blob/master/CHANGELOG.md).
+
+## Related blogposts:
+Learn more about some of the main methods of this library and their usage on 
+[these blogposts](http://shakedzy.xyz/dython/related_blogposts). 

--- a/README.md
+++ b/README.md
@@ -6,38 +6,15 @@
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/dython)](https://pypistats.org/packages/dython)
 [![License](https://img.shields.io/pypi/l/dython)](https://github.com/shakedzy/dython/blob/master/LICENSE)
 
-[![Coffee](https://img.shields.io/badge/-buy_me_a%C2%A0coffee-gray?logo=buy-me-a-coffee&color=ff69b4)](https://ko-fi.com/shakedzy)
-
 A set of **D**ata analysis tools in p**YTHON** 3.x.
 
-Dython was designed with analysis usage in mind - meaning ease-of-use, functionality and readability are the core 
-values of this library. Production-grade performance, on the other hand, were not considered.
-
-## Documentation:
-Modules documentation can be found on [shakedzy.xyz/dython](http://shakedzy.xyz/dython)
+Dython was implemented by shakedyzy. The official github is [here](https://github.com/shakedzy/dython). I modified this following my usage: only remove nan value in a pair of features when calculating association score.
 
 ## Installation:
-Dython can be installed directly using `pip`:
+If you wish to install my repo:
 ```
-pip install dython
-```
-Or, via the `conda` package manager:
-```
-conda install -c conda-forge dython
-```
-If you wish to install from source:
-```
-pip install git+https://github.com/shakedzy/dython.git
+pip install git+https://github.com/mainguyenanhvu/dython.git
 ```
 
 **Dependencies:** `numpy`, `pandas`, `seaborn`, `scipy`, `matplotlib`, `sklearn`, `scikit-plot`
 
-## Contributing:
-Contributions are always welcomed - if you found something you can fix, or have an idea for a new feature, feel free to write it and open a pull request. Please make sure to go over the [contributions guidelines](https://github.com/shakedzy/dython/blob/master/CONTRIBUTING.md).
-
-## Change log:
-Change log is available, see [CHANGELOG.md](https://github.com/shakedzy/dython/blob/master/CHANGELOG.md).
-
-## Related blogposts:
-Learn more about some of the main methods of this library and their usage on 
-[these blogposts](http://shakedzy.xyz/dython/related_blogposts). 

--- a/dython/nominal.py
+++ b/dython/nominal.py
@@ -298,39 +298,20 @@ def identify_numeric_columns(dataset):
     return identify_columns_by_type(dataset, include=['int64', 'float64'])
 
 
-def _comp_assoc(dataset, nominal_columns, numerical_columns, mark_columns, nom_nom_assoc, num_num_assoc,
-                bias_correction, nan_strategy, nan_replace_value, clustering):
+def _comp_assoc(dataset, nominal_columns, mark_columns, theil_u, clustering,
+                bias_correction, nan_strategy, nan_replace_value):
     """
     This is a helper function for compute_associations and associations
     """
     dataset = convert(dataset, 'dataframe')
 
-    if numerical_columns is not None:
-        if numerical_columns == 'auto':
-            nominal_columns = 'auto'
-        elif numerical_columns == 'all':
-            nominal_columns = None
-        else:
-            nominal_columns = [c for c in dataset.columns if c not in numerical_columns]
-
     # handling NaN values in data
     if nan_strategy == _REPLACE:
         dataset.fillna(nan_replace_value, inplace=True)
-    elif nan_strategy == _DROP_SAMPLES:
+    elif False:#nan_strategy == _DROP_SAMPLES:
         dataset.dropna(axis=0, inplace=True)
     elif nan_strategy == _DROP_FEATURES:
         dataset.dropna(axis=1, inplace=True)
-
-    # identifying categorical columns
-    columns = dataset.columns
-    auto_nominal = False
-    if nominal_columns is None:
-        nominal_columns = list()
-    elif nominal_columns == 'all':
-        nominal_columns = columns
-    elif nominal_columns == 'auto':
-        auto_nominal = True
-        nominal_columns = identify_nominal_columns(dataset)
 
     # convert timestamp columns to numerical columns, so correlation can be performed
     datetime_dtypes = [str(x) for x in dataset.dtypes if str(x).startswith('datetime64')]  # finding all timezones
@@ -339,8 +320,15 @@ def _comp_assoc(dataset, nominal_columns, numerical_columns, mark_columns, nom_n
         datetime_cols = [c for c in datetime_cols if c not in nominal_columns]
         if datetime_cols:
             dataset[datetime_cols] = dataset[datetime_cols].astype(np.int64)
-            if auto_nominal:
-                nominal_columns = identify_nominal_columns(dataset)
+
+    # identifying categorical columns
+    columns = dataset.columns
+    if nominal_columns is None:
+        nominal_columns = list()
+    elif nominal_columns == 'all':
+        nominal_columns = columns
+    elif nominal_columns == 'auto':
+        nominal_columns = identify_nominal_columns(dataset)
 
     corr = pd.DataFrame(index=columns, columns=columns)  # will be used to store associations values
 
@@ -364,56 +352,51 @@ def _comp_assoc(dataset, nominal_columns, numerical_columns, mark_columns, nom_n
             corr.loc[columns[i], :] = 0.0
             continue
         for j in range(i, len(columns)):
+            if nan_strategy == _DROP_SAMPLES:
+                temp = dataset[[columns[i],columns[j]]].dropna(axis=0)
+                column_i = temp[columns[i]]
+                column_j = temp[columns[j]]
             if columns[j] in single_value_columns:
                 continue
             elif i == j:
                 corr.loc[columns[i], columns[j]] = 1.0
             else:
-                if columns[i] in nominal_columns:
+                if len(column_i) <2  or len(column_j) < 2:
+                    ij = ji = 0
+                elif columns[i] in nominal_columns:
                     if columns[j] in nominal_columns:
-                        if nom_nom_assoc == 'theil':
+                        if theil_u:
                             ji = theils_u(
-                                dataset[columns[i]],
-                                dataset[columns[j]],
+                                column_i,
+                                column_j,
                                 nan_strategy=_SKIP)
                             ij = theils_u(
-                                dataset[columns[j]],
-                                dataset[columns[i]],
+                                column_j,
+                                column_i,
                                 nan_strategy=_SKIP)
-                        elif nom_nom_assoc == 'cramer':
-                            cell = cramers_v(dataset[columns[i]],
-                                             dataset[columns[j]],
-                                             bias_correction=bias_correction,
-                                             nan_strategy=_SKIP)
+                        else:
+                            cell = cramers_v(column_i,
+                                            column_j,
+                                            bias_correction=bias_correction,
+                                            nan_strategy=_SKIP)
                             ij = cell
                             ji = cell
-                        else:
-                            raise ValueError(f'{nom_nom_assoc} is not a supported nominal-nominal association')
                     else:
-                        cell = correlation_ratio(dataset[columns[i]],
-                                                 dataset[columns[j]],
-                                                 nan_strategy=_SKIP)
+                        cell = correlation_ratio(column_i,
+                                                column_j,
+                                                nan_strategy=_SKIP)
                         ij = cell
                         ji = cell
                 else:
-                    if columns[j] in nominal_columns:
-                        cell = correlation_ratio(dataset[columns[j]],
-                                                 dataset[columns[i]],
-                                                 nan_strategy=_SKIP)
+                    if columns[j] in nominal_columns:                        
+                        cell = correlation_ratio(column_j,
+                                                column_i,
+                                                nan_strategy=_SKIP)
                         ij = cell
                         ji = cell
                     else:
-                        if num_num_assoc == 'pearson':
-                            cell, _ = ss.pearsonr(dataset[columns[i]],
-                                                  dataset[columns[j]])
-                        elif num_num_assoc == 'spearman':
-                            cell, _ = ss.spearmanr(dataset[columns[i]],
-                                                   dataset[columns[j]])
-                        elif num_num_assoc == 'kendall':
-                            cell, _ = ss.kendalltau(dataset[columns[i]],
-                                                    dataset[columns[j]])
-                        else:
-                            raise ValueError(f'{num_num_assoc} is not a supported numerical-numerical association')
+                        cell, _ = ss.pearsonr(column_i,
+                                            column_j)
                         ij = cell
                         ji = cell
                 corr.loc[columns[i], columns[j]] = ij if not np.isnan(ij) and abs(ij) < np.inf else 0.0
@@ -443,14 +426,12 @@ def _comp_assoc(dataset, nominal_columns, numerical_columns, mark_columns, nom_n
 
 def compute_associations(dataset,
                          nominal_columns='auto',
-                         numerical_columns=None,
                          mark_columns=False,
-                         nom_nom_assoc='cramer',
-                         num_num_assoc='pearson',
+                         theil_u=False,
+                         clustering=False,
                          bias_correction=True,
                          nan_strategy=_REPLACE,
                          nan_replace_value=_DEFAULT_REPLACE_VALUE,
-                         clustering=False
                          ):
     """
     Calculate the correlation/strength-of-association of features in data-set
@@ -467,28 +448,21 @@ def compute_associations(dataset,
     -----------
     dataset : NumPy ndarray / Pandas DataFrame
         The data-set for which the features' correlation is computed
-    nominal_columns : string / list / NumPy ndarray, default = 'auto'
+    nominal_columns : string / list / NumPy ndarray
         Names of columns of the data-set which hold categorical values. Can
         also be the string 'all' to state that all columns are categorical,
         'auto' (default) to try to identify nominal columns, or None to state
-        none are categorical. Only used if `numerical_columns` is `None`.
-    numerical_columns : string / list / NumPy ndarray, default = None
-        To be used instead of `nominal_columns`. Names of columns of the data-set
-        which hold numerical values. Can also be the string 'all' to state that
-        all columns are numerical (equivalent to `nominal_columns=None`) or
-        'auto' to try to identify numerical columns (equivalent to
-        `nominal_columns=auto`). If `None`, `nominal_columns` is used.
+        none are categorical
     mark_columns : Boolean, default = False
         if True, output's columns' names will have a suffix of '(nom)' or
         '(con)' based on there type (eda_tools or continuous), as provided
         by nominal_columns
-    nom_nom_assoc : string, default = 'cramer'
-        Name of nominal-nominal (categorical-categorical) association to use.
-        Options are 'cramer' for Cramer's V or 'theil' for Theil's U. If 'theil',
-        heat-map rows are the provided information (U = U(row|col)).
-    num_num_assoc : string, default = 'pearson'
-        Name of numerical-numerical association to use. Options are 'pearson'
-        for Pearson's R, 'spearman' for Spearman's R, 'kendall' for Kendall's Tau.
+    theil_u : Boolean, default = False
+        In the case of categorical-categorical feaures, use Theil's U instead
+        of Cramer's V
+    clustering : Boolean, default = False
+        If True, hierarchical clustering is applied in order to sort
+        features into meaningful groups
     bias_correction : Boolean, default = True
         Use bias correction for Cramer's V from Bergsma and Wicher,
         Journal of the Korean Statistical Society 42 (2013): 323-328.
@@ -500,25 +474,22 @@ def compute_associations(dataset,
     nan_replace_value : any, default = 0.0
         The value used to replace missing values with. Only applicable when
         nan_strategy is set to 'replace'
-    clustering : Boolean, default = False
-        If True, hierarchical clustering is applied in order to sort
-        features into meaningful groups
 
     Returns:
     --------
     A DataFrame of the correlation/strength-of-association between all features
     """
-    corr, _, _, _, _ = _comp_assoc(dataset, nominal_columns, numerical_columns, mark_columns, nom_nom_assoc,
-                                   num_num_assoc, bias_correction, nan_strategy, nan_replace_value, clustering)
+    corr, _, _, _, _ = _comp_assoc(dataset, nominal_columns, mark_columns, theil_u, clustering,
+                                   bias_correction, nan_strategy, nan_replace_value)
     return corr
 
 
 def associations(dataset,
                  nominal_columns='auto',
-                 numerical_columns=None,
                  mark_columns=False,
-                 nom_nom_assoc='cramer',
-                 num_num_assoc='pearson',
+                 theil_u=False,
+                 plot=True,
+                 clustering=False,
                  bias_correction=True,
                  nan_strategy=_REPLACE,
                  nan_replace_value=_DEFAULT_REPLACE_VALUE,
@@ -531,8 +502,6 @@ def associations(dataset,
                  cbar=True,
                  vmax=1.0,
                  vmin=None,
-                 plot=True,
-                 clustering=False,
                  title=None,
                  filename=None
                  ):
@@ -547,28 +516,24 @@ def associations(dataset,
     -----------
     dataset : NumPy ndarray / Pandas DataFrame
         The data-set for which the features' correlation is computed
-    nominal_columns : string / list / NumPy ndarray, default = 'auto'
+    nominal_columns : string / list / NumPy ndarray
         Names of columns of the data-set which hold categorical values. Can
         also be the string 'all' to state that all columns are categorical,
         'auto' (default) to try to identify nominal columns, or None to state
-        none are categorical. Only used if `numerical_columns` is `None`.
-    numerical_columns : string / list / NumPy ndarray, default = None
-        To be used instead of `nominal_columns`. Names of columns of the data-set
-        which hold numerical values. Can also be the string 'all' to state that
-        all columns are numerical (equivalent to `nominal_columns=None`) or
-        'auto' to try to identify numerical columns (equivalent to
-        `nominal_columns=auto`). If `None`, `nominal_columns` is used.
+        none are categorical
     mark_columns : Boolean, default = False
         if True, output's columns' names will have a suffix of '(nom)' or
         '(con)' based on their type (nominal or continuous), as provided
         by nominal_columns
-    nom_nom_assoc : string, default = 'cramer'
-        Name of nominal-nominal (categorical-categorical) association to use.
-        Options are 'cramer' for Cramer's V or `theil` for Theil's U. If 'theil',
-        heat-map rows are the provided information (U = U(row|col)).
-    num_num_assoc : string, default = 'pearson'
-        Name of numerical-numerical association to use. Options are 'pearson'
-        for Pearson's R, 'spearman' for Spearman's R, 'kendall' for Kendall's Tau.
+    theil_u : Boolean, default = False
+        In the case of categorical-categorical feaures, use Theil's U instead
+        of Cramer's V. If selected, heat-map rows are the provided information
+        (U = U(row|col))
+    plot : Boolean, default = True
+        Plot a heat-map of the correlation matrix
+    clustering : Boolean, default = False
+        If True, hierarchical clustering is applied in order to sort
+        features into meaningful groups
     bias_correction : Boolean, default = True
         Use bias correction for Cramer's V from Bergsma and Wicher,
         Journal of the Korean Statistical Society 42 (2013): 323-328.
@@ -603,11 +568,6 @@ def associations(dataset,
         Set heat-map vmin option. If set to None, vmin will be chosen automatically
         between 0 and -1, depending on the types of associations used (-1 if Pearson's R
         is used, 0 otherwise)
-    plot : Boolean, default = True
-        Plot a heat-map of the correlation matrix
-    clustering : Boolean, default = False
-        If True, hierarchical clustering is applied in order to sort
-        features into meaningful groups
     title : string or None, default = None
         Plotted graph title
     filename : string or None, default = None
@@ -624,11 +584,9 @@ def associations(dataset,
     --------
     See examples under `dython.examples`
     """
-    corr, columns, nominal_columns, inf_nan, single_value_columns = _comp_assoc(dataset, nominal_columns,
-                                                                                numerical_columns, mark_columns,
-                                                                                nom_nom_assoc, num_num_assoc,
-                                                                                bias_correction, nan_strategy,
-                                                                                nan_replace_value, clustering)
+    corr, columns, nominal_columns, inf_nan, single_value_columns = _comp_assoc(dataset, nominal_columns, mark_columns,
+                                                                                theil_u, clustering, bias_correction,
+                                                                                nan_strategy, nan_replace_value)
     if ax is None:
         plt.figure(figsize=figsize)
     if inf_nan.any(axis=None):


### PR DESCRIPTION
I think removing all nan rows in the full table can lead to lack of fully evaluating data. I suggest only removing nan values in a temporary dataframe consisting of two columns during generating scores. Moreover, I added new check statement to avoid zero-size array error.